### PR TITLE
feat: add world boss tracking addon

### DIFF
--- a/MoPWorldBossTracker.lua
+++ b/MoPWorldBossTracker.lua
@@ -1,0 +1,276 @@
+
+local ADDON_NAME = ...
+
+local BOSS_QUEST_IDS = {
+    32099, -- Sha of Anger
+    32098, -- Galleon
+    32518, -- Nalak
+    32519, -- Oondasta
+    33117, -- Xuen
+    33118, -- Chi-Ji
+    33119, -- Yu'lon
+    33120, -- Niuzao
+    33121, -- Ordos
+}
+
+local function HasKilledAnyBoss()
+    for _, id in ipairs(BOSS_QUEST_IDS) do
+        if IsQuestFlaggedCompleted(id) then
+            return true
+        end
+    end
+    return false
+end
+
+local function GetCharKey()
+    local name, realm = UnitName("player")
+    realm = GetRealmName() or realm or "?"
+    return realm .. " - " .. name
+end
+
+local function ColorizeName(name, class)
+    local c = RAID_CLASS_COLORS[class]
+    if c and c.colorStr then
+        return "|c" .. c.colorStr .. name .. "|r"
+    end
+    return name
+end
+
+local DB
+
+local function EnsureDefaults()
+    DB = MoPWorldBossTrackerDB or {}
+    MoPWorldBossTrackerDB = DB
+    DB.chars = DB.chars or {}
+    DB.minimap = DB.minimap or { hide = false }
+    DB.framePos = DB.framePos or {}
+    DB.lastResetAt = DB.lastResetAt or 0
+end
+
+local function UpdateCharacter()
+    local level = UnitLevel("player")
+    if level < 90 then return end
+    local key = GetCharKey()
+    local _, classFile = UnitClass("player")
+    local char = DB.chars[key] or {}
+    char.level = level
+    char.class = classFile
+    char.lastSeen = time()
+    char.killed = HasKilledAnyBoss()
+    DB.chars[key] = char
+end
+
+local function GetNextWeeklyReset()
+    local now = time()
+    if C_DateAndTime and C_DateAndTime.GetSecondsUntilWeeklyReset then
+        return now + C_DateAndTime.GetSecondsUntilWeeklyReset()
+    else
+        return now + 7 * 24 * 60 * 60
+    end
+end
+
+local function CheckReset()
+    local now = time()
+    if not DB.lastResetAt or now >= DB.lastResetAt then
+        DB.lastResetAt = GetNextWeeklyReset()
+        for _, char in pairs(DB.chars) do
+            char.killed = nil
+        end
+        return true
+    end
+    return false
+end
+
+local mainFrame
+
+local function RefreshUI()
+    if not mainFrame or not mainFrame:IsShown() then return end
+    UpdateCharacter()
+
+    for _, line in ipairs(mainFrame.lines) do
+        line:Hide()
+    end
+    wipe(mainFrame.lines)
+
+    local index = 0
+    for name, info in pairs(DB.chars) do
+        if info.level and info.level >= 90 and not info.killed then
+            index = index + 1
+            local line = mainFrame.lines[index]
+            if not line then
+                line = mainFrame.content:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+                mainFrame.lines[index] = line
+                line:SetPoint("TOPLEFT", 0, -(index - 1) * 20)
+                line:SetPoint("RIGHT")
+            end
+            line:SetText(ColorizeName(name, info.class))
+            line:Show()
+        end
+    end
+
+    if index == 0 then
+        mainFrame.message:Show()
+    else
+        mainFrame.message:Hide()
+    end
+    mainFrame.content:SetHeight(index * 20)
+end
+
+local function ToggleFrame()
+    if mainFrame:IsShown() then
+        mainFrame:Hide()
+    else
+        mainFrame:Show()
+        RefreshUI()
+    end
+end
+
+local function ShowFrame()
+    if not mainFrame:IsShown() then
+        mainFrame:Show()
+    end
+    RefreshUI()
+end
+
+local function HideFrame()
+    mainFrame:Hide()
+end
+
+local function UpdateMinimapButton()
+    if DB.minimap.hide then
+        MoPWorldBossTrackerMinimapButton:Hide()
+    else
+        MoPWorldBossTrackerMinimapButton:Show()
+    end
+end
+
+local function ToggleMinimapButton()
+    DB.minimap.hide = not DB.minimap.hide
+    UpdateMinimapButton()
+end
+
+local function CreateMinimapButton()
+    local button = CreateFrame("Button", "MoPWorldBossTrackerMinimapButton", Minimap)
+    button:SetSize(32, 32)
+    button:SetFrameStrata("MEDIUM")
+    button:SetFrameLevel(8)
+    button:SetPoint("TOPLEFT", Minimap, "TOPLEFT")
+
+    local icon = button:CreateTexture(nil, "BACKGROUND")
+    icon:SetTexture("Interface\\Icons\\inv_misc_map_01")
+    icon:SetSize(20, 20)
+    icon:SetPoint("CENTER")
+
+    button:SetScript("OnClick", ToggleFrame)
+
+    UpdateMinimapButton()
+end
+
+local function LoadPosition()
+    local pos = DB.framePos
+    if pos.point then
+        mainFrame:ClearAllPoints()
+        mainFrame:SetPoint(pos.point, UIParent, pos.relativePoint, pos.x, pos.y)
+    else
+        mainFrame:SetPoint("CENTER")
+    end
+end
+
+local function SavePosition()
+    local point, _, relativePoint, x, y = mainFrame:GetPoint()
+    DB.framePos.point = point
+    DB.framePos.relativePoint = relativePoint
+    DB.framePos.x = x
+    DB.framePos.y = y
+end
+
+local function CreateMainFrame()
+    mainFrame = CreateFrame("Frame", "MoPWorldBossTrackerFrame", UIParent, "BackdropTemplate")
+    mainFrame:SetSize(300, 200)
+    mainFrame:SetClampedToScreen(true)
+    mainFrame:SetMovable(true)
+    mainFrame:EnableMouse(true)
+    mainFrame:RegisterForDrag("LeftButton")
+    mainFrame:SetScript("OnDragStart", mainFrame.StartMoving)
+    mainFrame:SetScript("OnDragStop", function(self) self:StopMovingOrSizing(); SavePosition() end)
+    mainFrame:SetScript("OnShow", RefreshUI)
+    mainFrame:Hide()
+
+    mainFrame:SetBackdrop({
+        bgFile = "Interface\\DialogFrame\\UI-DialogBox-Background",
+        edgeFile = "Interface\\DialogFrame\\UI-DialogBox-Border",
+        tile = true,
+        tileSize = 32,
+        edgeSize = 32,
+        insets = { left = 11, right = 12, top = 12, bottom = 11 },
+    })
+
+    local title = mainFrame:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    title:SetPoint("TOP", 0, -10)
+    title:SetText("MoP World Boss Tracker")
+    mainFrame.title = title
+
+    local close = CreateFrame("Button", nil, mainFrame, "UIPanelCloseButton")
+    close:SetPoint("TOPRIGHT", -5, -5)
+    close:SetScript("OnClick", HideFrame)
+
+    local scrollFrame = CreateFrame("ScrollFrame", nil, mainFrame, "UIPanelScrollFrameTemplate")
+    scrollFrame:SetPoint("TOPLEFT", 16, -32)
+    scrollFrame:SetPoint("BOTTOMRIGHT", -32, 16)
+
+    local content = CreateFrame("Frame", nil, scrollFrame)
+    content:SetSize(1, 1)
+    scrollFrame:SetScrollChild(content)
+    mainFrame.content = content
+
+    mainFrame.lines = {}
+    mainFrame.message = content:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    mainFrame.message:SetPoint("TOP", 0, -10)
+    mainFrame.message:SetText("All set for this week!")
+    mainFrame.message:Hide()
+
+    LoadPosition()
+end
+
+SLASH_MOPWB1 = "/mopwb"
+SlashCmdList["MOPWB"] = function(msg)
+    msg = msg and msg:lower() or ""
+    if msg == "show" then
+        ShowFrame()
+    elseif msg == "hide" then
+        HideFrame()
+    elseif msg == "minimap" then
+        ToggleMinimapButton()
+    else
+        ToggleFrame()
+    end
+end
+
+local eventFrame = CreateFrame("Frame")
+eventFrame:RegisterEvent("PLAYER_LOGIN")
+eventFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+
+eventFrame:SetScript("OnEvent", function(self, event)
+    if event == "PLAYER_LOGIN" then
+        EnsureDefaults()
+        CreateMainFrame()
+        CreateMinimapButton()
+        CheckReset()
+        UpdateCharacter()
+    elseif event == "PLAYER_ENTERING_WORLD" then
+        CheckReset()
+        UpdateCharacter()
+        RefreshUI()
+    end
+end)
+
+local elapsed = 0
+eventFrame:SetScript("OnUpdate", function(self, e)
+    elapsed = elapsed + e
+    if elapsed > 60 then
+        elapsed = 0
+        if CheckReset() then
+            RefreshUI()
+        end
+    end
+end)

--- a/MoPWorldBossTracker.toc
+++ b/MoPWorldBossTracker.toc
@@ -1,0 +1,8 @@
+## Interface: 50001
+## Title: MoP World Boss Tracker
+## Author: ChatGPT
+## Version: 1.0.0
+## Notes: Track which characters have not killed any MoP world bosses this week
+## SavedVariables: MoPWorldBossTrackerDB
+
+MoPWorldBossTracker.lua

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# MoP World Boss Tracker
+
+MoPWorldBossTracker is a World of Warcraft addon for Mists of Pandaria Classic that tracks which level 90+ characters on your account still need to kill any MoP world boss for the current weekly reset.
+
+## Features
+- Minimap button and `/mopwb` slash command to toggle the tracker frame
+- Draggable frame with persistent position
+- Lists only characters who have not killed any world boss this week
+- Automatically handles weekly reset boundaries
+
+## Slash Commands
+```
+/mopwb          Toggle the tracker frame
+/mopwb show     Show the tracker frame
+/mopwb hide     Hide the tracker frame
+/mopwb minimap  Toggle the minimap button
+```
+
+## World Boss Quest IDs
+- Sha of Anger — 32099
+- Galleon — 32098
+- Nalak — 32518
+- Oondasta — 32519
+- Celestials — 33117–33120
+- Ordos — 33121


### PR DESCRIPTION
## Summary
- add Mists of Pandaria world boss tracking addon with minimap button and slash commands
- provide README with quest IDs and usage instructions

## Testing
- `luac -p MoPWorldBossTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_689da110db008333911430620918db9c