### PR TITLE
fix: add quest completion fallback

### DIFF
--- a/MoPWorldBossTracker.lua
+++ b/MoPWorldBossTracker.lua
@@ -13,9 +13,18 @@ local BOSS_QUEST_IDS = {
     33121, -- Ordos
 }
 
+local function IsQuestCompleted(id)
+    if C_QuestLog and C_QuestLog.IsQuestFlaggedCompleted then
+        return C_QuestLog.IsQuestFlaggedCompleted(id)
+    elseif _G.IsQuestFlaggedCompleted then
+        return _G.IsQuestFlaggedCompleted(id)
+    end
+    return false
+end
+
 local function HasKilledAnyBoss()
     for _, id in ipairs(BOSS_QUEST_IDS) do
-        if IsQuestFlaggedCompleted(id) then
+        if IsQuestCompleted(id) then
             return true
         end
     end


### PR DESCRIPTION
## Summary
- handle missing IsQuestFlaggedCompleted by checking modern API fallback

## Testing
- `luac -p MoPWorldBossTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_689daabdce7883338935e2be7036c56d