### PR TITLE
fix: check quests with GetQuestsCompleted

### DIFF
--- a/MoPWorldBossTracker.lua
+++ b/MoPWorldBossTracker.lua
@@ -14,10 +14,9 @@ local BOSS_QUEST_IDS = {
 }
 
 local function IsQuestCompleted(id)
-    if C_QuestLog and C_QuestLog.IsQuestFlaggedCompleted then
-        return C_QuestLog.IsQuestFlaggedCompleted(id)
-    elseif _G.IsQuestFlaggedCompleted then
-        return _G.IsQuestFlaggedCompleted(id)
+    if GetQuestsCompleted then
+        local completed = GetQuestsCompleted()
+        return completed and completed[id] or false
     end
     return false
 end


### PR DESCRIPTION
## Summary
- use `GetQuestsCompleted` to detect world boss quest status

## Testing
- `luac -p MoPWorldBossTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_689db66fd1608333b43bcdf9e8322ef2