### PR TITLE
feat: allow selecting tracked bosses

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - Minimap button and `/mopwb` slash commands to toggle the tracker frame
 - Draggable frame with persistent position
 - Option to display all characters or only those who still need world boss kills
+- Options panel to choose which bosses are tracked
 - Shows each world boss a character still needs this week
 - Automatically handles weekly reset boundaries
 - Low memory usage
@@ -18,6 +19,8 @@
 ## Usage
 
 Toggle the tracker frame via the minimap button or `/mopwb toggle`. The frame shows your level 90+ characters that still need MoP world boss kills for the week. Use `/mopwb show` or `/mopwb hide` to control visibility, `/mopwb minimap` to toggle the minimap button, `/mopwb all` to display every character, and `/mopwb todo` to show only those still needing kills.
+
+Select which bosses are tracked via the addon options panel in the Interface menu.
 
 ---
 


### PR DESCRIPTION
## Summary
- add options panel with checkboxes for each boss
- allow enabling or disabling tracked bosses and persist preference

## Testing
- `luac -p MoPWorldBossTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_689dbc20c6688333beafc5c50f6409fd