### PR TITLE
fix: prevent boolean killed state from causing errors

### DIFF
--- a/MoPWorldBossTracker.lua
+++ b/MoPWorldBossTracker.lua
@@ -75,7 +75,7 @@ local function UpdateCharacter()
     char.level = level
     char.class = classFile
     char.lastSeen = time()
-    char.killed = char.killed or {}
+    char.killed = type(char.killed) == "table" and char.killed or {}
     for _, boss in ipairs(BOSSES) do
         if IsQuestCompleted(boss.questId) then
             char.killed[boss.questId] = true


### PR DESCRIPTION
## Summary
- ensure character kill tracking is a table before indexing

## Testing
- `luac -p MoPWorldBossTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_689dbe1c36cc8333880a12b153413c7e