### PR TITLE
fix: register options panel with Settings API

### DIFF
--- a/MoPWorldBossTracker.lua
+++ b/MoPWorldBossTracker.lua
@@ -335,7 +335,12 @@ local function CreateOptionsPanel()
         last = cb
     end
 
-    InterfaceOptions_AddCategory(optionsPanel)
+    if InterfaceOptions_AddCategory then
+        InterfaceOptions_AddCategory(optionsPanel)
+    elseif Settings and Settings.RegisterCanvasLayoutCategory then
+        local category = Settings.RegisterCanvasLayoutCategory(optionsPanel, optionsPanel.name)
+        Settings.RegisterAddOnCategory(category)
+    end
 end
 
 SLASH_MOPWB1 = "/mopwb"


### PR DESCRIPTION
## Summary
- handle InterfaceOptions_AddCategory removal by falling back to Settings API

## Testing
- `luac -p MoPWorldBossTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_689dc0e4113c833395c4454bb01a2e1d