### PR TITLE
fix: update frame resizing API

### DIFF
--- a/MoPWorldBossTracker.lua
+++ b/MoPWorldBossTracker.lua
@@ -274,7 +274,11 @@ local function CreateMainFrame()
     mainFrame:SetClampedToScreen(true)
     mainFrame:SetMovable(true)
     mainFrame:SetResizable(true)
-    mainFrame:SetMinResize(200, 150)
+    if mainFrame.SetResizeBounds then
+        mainFrame:SetResizeBounds(200, 150)
+    else
+        mainFrame:SetMinResize(200, 150)
+    end
     mainFrame:EnableMouse(true)
     mainFrame:RegisterForDrag("LeftButton")
     mainFrame:SetScript("OnDragStart", mainFrame.StartMoving)


### PR DESCRIPTION
## Summary
- use `SetResizeBounds` when available and fall back to `SetMinResize`

## Testing
- `luac -p MoPWorldBossTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_689dc8fb78508333a7d6727279add2f4