### PR TITLE
feat: add configurable logging with verbosity levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - Automatically handles weekly reset boundaries
 - Low memory usage
 - `/mopwb version` prints the addon version and currently active bosses
+- Configurable logging with three verbosity levels
 
 ---
 


### PR DESCRIPTION
## Summary
- add logging infrastructure with error, info and debug levels
- expose log level in expandable options panels
- document logging feature in README

## Testing
- `~/.luarocks/bin/luacheck MoPWorldBossTracker.lua`
- `luac -p MoPWorldBossTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_689dfd237e2883338d15e0157577bef3