### PR TITLE
refactor: simplify line display logic

### DIFF
--- a/MoPWorldBossTracker.lua
+++ b/MoPWorldBossTracker.lua
@@ -207,10 +207,8 @@ local function RefreshUI()
                     if not line then
                         line = AddTextToFrame(mainFrame.content, "", "TOPLEFT", 0, -(index - 1) * 20)
                         mainFrame.lines[index] = line
-                        line:SetPoint("RIGHT")
                     end
                     line:SetText(ColorizeName(name, info.class) .. " - done")
-                    line:Show()
                 else
                     for _, bossName in ipairs(missing) do
                         index = index + 1
@@ -218,10 +216,8 @@ local function RefreshUI()
                         if not line then
                             line = AddTextToFrame(mainFrame.content, "", "TOPLEFT", 0, -(index - 1) * 20)
                             mainFrame.lines[index] = line
-                            line:SetPoint("RIGHT")
                         end
                         line:SetText(ColorizeName(name, info.class) .. " - " .. bossName)
-                        line:Show()
                     end
                 end
             end


### PR DESCRIPTION
## Summary
- simplify refreshing UI lines by removing redundant SetPoint and Show calls

## Testing
- `luac -p MoPWorldBossTracker.lua`

------
https://chatgpt.com/codex/tasks/task_e_689e2406e52c83339b4134a559c620a8