### PR TITLE
fix: ensure addon icon displays

### DIFF
--- a/MoPWorldBossTracker.toc
+++ b/MoPWorldBossTracker.toc
@@ -3,6 +3,7 @@
 ## Author: ChatGPT
 ## Version: 1.1.0
 ## Notes: Track which characters have not killed any MoP world bosses this week
+## IconTexture: Interface\Icons\Achievement_Boss_ShaofAnger
 ## SavedVariables: MoPWorldBossTrackerDB
 
 MoPWorldBossTracker.lua


### PR DESCRIPTION
## Summary
- add IconTexture metadata so addon icon shows in the interface

## Testing
- `luac -p MoPWorldBossTracker.lua`


------
https://chatgpt.com/codex/tasks/task_e_689e48f6c3588333bcbf2e99da7f5a57