### PR TITLE
feat: use custom icon for minimap button

### DIFF
--- a/MoPWorldBossTracker.lua
+++ b/MoPWorldBossTracker.lua
@@ -337,7 +337,7 @@ local function CreateMinimapButton()
     button:SetPoint("TOPLEFT", Minimap, "TOPLEFT")
 
     local icon = button:CreateTexture(nil, "BACKGROUND")
-    icon:SetTexture("Interface\\Icons\\Achievement_Boss_ShaofAnger")
+    icon:SetTexture("Interface\\AddOns\\MoPWorldBossTracker\\MopWorldBossTracker_icon.tga")
     icon:SetSize(20, 20)
     icon:SetPoint("CENTER")
 

--- a/MoPWorldBossTracker.toc
+++ b/MoPWorldBossTracker.toc
@@ -3,7 +3,7 @@
 ## Author: ChatGPT
 ## Version: 1.1.0
 ## Notes: Track which characters have not killed any MoP world bosses this week
-## IconTexture: Interface\Icons\Achievement_Boss_ShaofAnger
+## IconTexture: MopWorldBossTracker_icon.tga
 ## SavedVariables: MoPWorldBossTrackerDB
 
 MoPWorldBossTracker.lua


### PR DESCRIPTION
## Summary
- use custom MopWorldBossTracker icon for minimap button
- update addon metadata to reference custom icon

## Testing
- `luac -p MoPWorldBossTracker.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f42588a408333aa0fcce8211c8781